### PR TITLE
fix(prometheus): adjust port name in scrape config

### DIFF
--- a/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/istio-telemetry/prometheus/templates/configmap.yaml
@@ -97,7 +97,7 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: istio-policy;http-monitoring
+        regex: istio-policy;http-policy-monitoring
 
     - job_name: 'istio-telemetry'
       kubernetes_sd_configs:


### PR DESCRIPTION
The port name in the service config for `istio-policy` was changed from `http-monitoring` to `http-policy-monitoring`. This PR updates the prom scrape config to match that change and allow the self-monitoring metrics from `istio-policy` endpoints to continue to be collected.

If the change of service port names was not intentional, or is not desired, we should change the value there instead.