### PR TITLE
Remove Injector dependency on MeshConfig

### DIFF
--- a/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/istio-control/istio-autoinject/files/injection-template.yaml
@@ -13,7 +13,7 @@ initContainers:
   command:
   - "/usr/local/bin/istio-iptables.sh"
   - "-p"
-  - "{{ .MeshConfig.ProxyListenPort }}"
+  - 15001
   - "-u"
   - 1337
   - "-m"


### PR DESCRIPTION
The only field it references is one that is not configurable anyways, so
we can hard code it in the template safely. If it does need to be
configured in the future, we should read from values directly rather
than MeshConfig.

Part of https://github.com/istio-ecosystem/istio-installer/issues/75