### PR TITLE
Fix configValidation setting

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -228,9 +228,6 @@ global:
   # the desired values.
   defaultNodeSelector: {}
 
-  # Whether to perform server-side validation of configuration.
-  configValidation: true
-
   # Custom DNS config for the pod to resolve names of services in other
   # clusters. Use this to add additional search domains, and other settings.
   # see

--- a/istio-control/istio-config/values.yaml
+++ b/istio-control/istio-config/values.yaml
@@ -13,4 +13,4 @@ galley:
   # TODO: Galley appears to use the mesh config - need to find which fields are used and need to be configured.
   mesh: {}
 
-  configValidation: false
+  configValidation: true


### PR DESCRIPTION
It was previously at the global level (no effect) and turned off by
default (should be on by default).

Signed-off-by: John Howard <howardjohn@google.com>

@costinm this should be on by default right? If not we will probably get tons of issues from users appliyng invalid config